### PR TITLE
Changed HexAddressPubKey to use actual bytes and not amino encoded bytes

### DIFF
--- a/types/address.go
+++ b/types/address.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/tendermint/tendermint/crypto/ed25519"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
 	"gopkg.in/yaml.v2"
 
 	"github.com/tendermint/tendermint/crypto"
@@ -202,10 +204,30 @@ func GetAddress(pubkey crypto.PubKey) Address {
 // auxiliary
 // ----------------------------------------------------------------------------
 
+//HexAddressPubKey gets a Hex encoded string from the pubKey raw byte array
+//if the the type cannot be asserted returns from amino encoded bytes
 func HexAddressPubKey(pub crypto.PubKey) string {
+	//type Assertion
+	switch v := pub.(type) {
+	case ed25519.PubKeyEd25519:
+		//Raw Bytes
+		v.Bytes()
+		return hex.EncodeToString(v[:])
+	case secp256k1.PubKeySecp256k1:
+		//Raw Bytes
+		return hex.EncodeToString(v[:])
+	default:
+		//Amino Bytes
+		return hex.EncodeToString(pub.Bytes())
+	}
+}
+
+//HexAddressPubKeyAmino gets a Hex encoded string from the pubKey amino encoded byte array
+func HexAddressPubKeyAmino(pub crypto.PubKey) string {
 	return hex.EncodeToString(pub.Bytes())
 }
 
+// GetAddressPubKeyFromHex decodes PublicKey from a Hex encoded string.
 func GetAddressPubKeyFromHex(pubkey string) (pk crypto.PubKey, err error) {
 
 	bz, err := GetFromHex(pubkey)
@@ -251,11 +273,9 @@ func AccAddressFromHex(address string) (addr Address, err error) {
 func GetAccPubKeyHex(pubkey string) (pk crypto.PubKey, err error) {
 	return GetAddressPubKeyFromHex(pubkey)
 }
-
 func GetValPubKeyHex(pubkey string) (pk crypto.PubKey, err error) {
 	return GetAddressPubKeyFromHex(pubkey)
 }
-
 func GetConsPubKeyHex(pubkey string) (pk crypto.PubKey, err error) {
 	return GetAddressPubKeyFromHex(pubkey)
 }

--- a/types/address_test.go
+++ b/types/address_test.go
@@ -3,6 +3,7 @@ package types_test
 import (
 	"encoding/hex"
 	"fmt"
+	"github.com/tendermint/tendermint/crypto"
 	"math/rand"
 	"testing"
 
@@ -192,6 +193,42 @@ func TestAddressInterface(t *testing.T) {
 		case types.Address:
 			_, err := types.AddressFromHex(addr.String())
 			require.Nil(t, err)
+		default:
+			t.Fail()
+		}
+	}
+
+}
+
+func TestPubKeyInterfaceAssertion(t *testing.T) {
+	var pub ed25519.PubKeyEd25519
+	rand.Read(pub[:])
+	var pub2 secp256k1.PubKeySecp256k1
+	rand.Read(pub2[:])
+
+	values := []crypto.PubKey{
+		pub, pub2,
+	}
+
+	for _, v := range values {
+		switch v := v.(type) {
+		case ed25519.PubKeyEd25519:
+			fmt.Println(v)
+			s := types.HexAddressPubKey(v)
+			as := types.HexAddressPubKeyAmino(v)
+			fmt.Println(s)
+			fmt.Println(as)
+			require.NotNil(t, s)
+			require.NotEqual(t, s, as)
+
+		case secp256k1.PubKeySecp256k1:
+			fmt.Println(v)
+			s := types.HexAddressPubKey(v)
+			as := types.HexAddressPubKeyAmino(v)
+			fmt.Println(s)
+			fmt.Println(as)
+			require.NotNil(t, s)
+			require.NotEqual(t, s, as)
 		default:
 			t.Fail()
 		}


### PR DESCRIPTION
Changes:

- Changed func HexAddressPubKey to return expected values
- Created alternate func HexAddressPubKeyAmino to return amino bytes
- Created Tests

Closes #64 

