### PR TITLE
custom marshaller and unmarshaller ed25519.go, uses rawstring for json.

### DIFF
--- a/crypto/common_test.go
+++ b/crypto/common_test.go
@@ -6,7 +6,16 @@ func getRandomPrivateKey(t *testing.T) Ed25519PrivateKey {
 	return Ed25519PrivateKey{}.GenPrivateKey().(Ed25519PrivateKey)
 }
 
+func getRandomPrivateKeySecp(t *testing.T) Secp256k1PrivateKey {
+	return Secp256k1PrivateKey{}.GenPrivateKey().(Secp256k1PrivateKey)
+}
+
 func getRandomPubKey(t *testing.T) Ed25519PublicKey {
 	pk := getRandomPrivateKey(t)
 	return pk.PublicKey().(Ed25519PublicKey)
+}
+
+func getRandomPubKeySecp(t *testing.T) Secp256k1PublicKey {
+	pk := getRandomPrivateKeySecp(t)
+	return pk.PublicKey().(Secp256k1PublicKey)
 }

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -3,8 +3,10 @@ package crypto
 import (
 	ed255192 "crypto/ed25519"
 	"encoding/hex"
+	"encoding/json"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
+	"strings"
 )
 
 type (
@@ -76,6 +78,30 @@ func (pub Ed25519PublicKey) Equals(other crypto.PubKey) bool {
 
 func (pub Ed25519PublicKey) Size() int {
 	return Ed25519PubKeySize
+}
+
+func (pub Ed25519PublicKey) MarshalJSON() ([]byte, error) {
+	return json.Marshal(pub.RawString())
+}
+
+func (pub *Ed25519PublicKey) UnmarshalJSON(data []byte) error {
+	hexstring := strings.Trim(string(data[:]), "\"")
+
+	bytes, err := hex.DecodeString(hexstring)
+	if err != nil {
+		return err
+	}
+	pk, err := NewPublicKeyBz(bytes)
+	if err != nil {
+		return err
+	}
+	err = cdc.UnmarshalBinaryBare(pk.Bytes(), pub)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (priv Ed25519PrivateKey) RawBytes() []byte {

--- a/crypto/encode_test.go
+++ b/crypto/encode_test.go
@@ -108,6 +108,17 @@ func TestEd25519PublicKeyCustomMarshalling(t *testing.T) {
 	require.EqualValues(t, pub, pub2)
 }
 
+func TestSecp256k1PublicKeyCustomMarshalling(t *testing.T) {
+
+	//Get a Random PubKey
+	pub := getRandomPubKeySecp(t)
+	var pub2 Secp256k1PublicKey
+	//Do Marshalling and Unmarshalling
+	checkJSONMarshalUnMarshal(t, pub, &pub2)
+	//Pub2 should have the same value if everything is ok.
+	require.EqualValues(t, pub, pub2)
+}
+
 func TestNilEncodings(t *testing.T) {
 
 	// Check nil Signature.

--- a/crypto/encode_test.go
+++ b/crypto/encode_test.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"encoding/json"
 	"github.com/stretchr/testify/assert"
 	"testing"
 
@@ -40,6 +41,15 @@ func checkAminoJSON(t *testing.T, src interface{}, dst interface{}, isNil bool) 
 	}
 	// Unmarshal.
 	err = cdc.UnmarshalJSON(js, dst)
+	require.Nil(t, err, "%+v", err)
+}
+
+func checkJSONMarshalUnMarshal(t *testing.T, src interface{}, dst interface{}) {
+	// Marshal to JSON bytes.
+	jbytes, err := json.Marshal(src)
+	require.Nil(t, err, "%+v", err)
+	// Unmarshal.
+	err = json.Unmarshal(jbytes, dst)
 	require.Nil(t, err, "%+v", err)
 }
 
@@ -85,6 +95,17 @@ func TestKeyEncodings(t *testing.T) {
 		checkAminoJSON(t, pubKey, &pub3, false) // TODO also check Prefix bytes.
 		require.EqualValues(t, pubKey, pub3)
 	}
+}
+
+func TestEd25519PublicKeyCustomMarshalling(t *testing.T) {
+
+	//Get a Random PubKey
+	pub := getRandomPubKey(t)
+	var pub2 Ed25519PublicKey
+	//Do Marshalling and Unmarshalling
+	checkJSONMarshalUnMarshal(t, pub, &pub2)
+	//Pub2 should have the same value if everything is ok.
+	require.EqualValues(t, pub, pub2)
 }
 
 func TestNilEncodings(t *testing.T) {

--- a/crypto/secp256k1.go
+++ b/crypto/secp256k1.go
@@ -2,8 +2,10 @@ package crypto
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
+	"strings"
 )
 
 type (
@@ -75,6 +77,30 @@ func (pub Secp256k1PublicKey) Equals(other crypto.PubKey) bool {
 
 func (pub Secp256k1PublicKey) Size() int {
 	return Secp256k1PublicKeySize
+}
+
+func (pub Secp256k1PublicKey) MarshalJSON() ([]byte, error) {
+	return json.Marshal(pub.RawString())
+}
+
+func (pub *Secp256k1PublicKey) UnmarshalJSON(data []byte) error {
+	hexstring := strings.Trim(string(data[:]), "\"")
+
+	bytes, err := hex.DecodeString(hexstring)
+	if err != nil {
+		return err
+	}
+	pk, err := NewPublicKeyBz(bytes)
+	if err != nil {
+		return err
+	}
+	err = cdc.UnmarshalBinaryBare(pk.Bytes(), pub)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (priv Secp256k1PrivateKey) RawBytes() []byte {


### PR DESCRIPTION
closes #149 